### PR TITLE
Add Rollbar support for deploys

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         'A task runner, package builder, deploy tool'
     ),
     long_description=long_description,
-    version='0.6',
+    version='0.7',
     url='https://github.com/RoundingWellOS/deckard',
     author=u'Hernán Ciudad',
     author_email='hernan@roundingwell.com',


### PR DESCRIPTION
Notifies Rollbar of new release after completing release tasks. 

Depends on an environment variable being set for "ROLLBAR_TOKEN_SERVER" that represents the rollbar Project Access token post_server_item.